### PR TITLE
modify nvmestore factory function and blk_alloc_aep api

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -4,3 +4,4 @@ set(CMAKE_CXX_STANDARD 11)
 
 add_subdirectory (block-perf)
 add_subdirectory (paging-tracker)
+#add_subdirectory(cuda-dma)

--- a/src/components/allocator/block/src/block_allocator.h
+++ b/src/components/allocator/block/src/block_allocator.h
@@ -166,10 +166,11 @@ public:
   }
 
 virtual Component::IBlock_allocator * open_allocator(  size_t max_lba,
-                                                       Component::persist_id_t id,
+                                                       std::string path,
+                                                       std::string name,
                                                        int numa_node,
                                                        bool force_init) override{
-  return NULL; 
+    throw API_exception("not implemented.");
   }
 
 };

--- a/src/components/api/block_allocator_itf.h
+++ b/src/components/api/block_allocator_itf.h
@@ -49,12 +49,13 @@ public:
    * Open allocator using AEP
    * 
    * @param max_lba Maximum LBA to track
-   * @param name Allocator persistent identifier
-   * 
+   * @param path, path of the pool to store the allocation info
+   * @param name, the name of the stored allocation info
    * @return 
    */
   virtual IBlock_allocator * open_allocator(size_t max_lba,
-                                            persist_id_t persistent_id,
+                                            std::string path,
+                                            std::string name,
                                             int numa_node = NUMA_NODE_ANY,
                                             bool force_init = false){
     throw API_exception("not implemented.");

--- a/src/components/api/kvstore_itf.h
+++ b/src/components/api/kvstore_itf.h
@@ -321,17 +321,7 @@ public:
   DECLARE_INTERFACE_UUID(0xface829f,0x0405,0x4c19,0x9898,0xa3,0xae,0x21,0x5a,0x3e,0xe8);
 
   virtual IKVStore * create(const std::string owner,
-                            const std::string name){
-    throw API_exception("not implemented.");
-  }
-
-  virtual IKVStore * create(const std::string owner,
-                            const std::string name,  
-                             Component::IBlock_device *blk_dev,
-                             Component::IBlock_allocator *blk_alloc){
-    throw API_exception("not implemented.");
-  }
-  
+                            const std::string name) =0;
 
 };
 

--- a/testing/kvstore/kvstore_perf.cpp
+++ b/testing/kvstore/kvstore_perf.cpp
@@ -7,9 +7,6 @@
 #include <boost/program_options.hpp>
 #include <chrono>
 #include <gperftools/profiler.h>
-
-#include <core/dpdk.h>
-
 #define PATH "/mnt/pmem0/"
 //#define PATH "/dev/dax0.0"
 #define POOL_NAME "test.pool"
@@ -31,11 +28,6 @@ Data * _data;
 static Component::IKVStore * g_store;
 static void initialize();
 static void cleanup();
-
-// required for nvmestore
-static Component::IBlock_device  *_block;
-static Component::IBlock_allocator *_alloc;
-static size_t _nr_blks; //number of blocks from IBlockdev
 
 struct {
   std::string test;
@@ -125,8 +117,7 @@ static void initialize()
     comp = Component::load_component(FILESTORE_PATH, Component::filestore_factory);
   }
   else if(Options.component == "nvmestore") {
-    comp = Component::load_component("libcomanche-nvmestore.so",
-                                                        Component::nvmestore_factory);
+    comp = Component::load_component(NVMESTORE_PATH, Component::nvmestore_factory);
   }
   else if(Options.component == "rockstore") {
     comp = Component::load_component(ROCKSTORE_PATH, Component::rocksdb_factory);
@@ -136,7 +127,7 @@ static void initialize()
   assert(comp);
   IKVStore_factory * fact = (IKVStore_factory *) comp->query_interface(IKVStore_factory::iid());
 
-  g_store = fact->create("owner","name"); 
+  g_store = fact->create("owner","name");
   fact->release_ref();
 }
 

--- a/testing/kvstore/kvstore_perf.cpp
+++ b/testing/kvstore/kvstore_perf.cpp
@@ -7,11 +7,14 @@
 #include <boost/program_options.hpp>
 #include <chrono>
 #include <gperftools/profiler.h>
+
+#include <core/dpdk.h>
+
 #define PATH "/mnt/pmem0/"
 //#define PATH "/dev/dax0.0"
 #define POOL_NAME "test.pool"
 
-#define PMSTORE_PATH "/home/danielwaddington/comanche/build/comanche-restricted/src/components/pmstore/libcomanche-pmstore.so"
+#define PMSTORE_PATH "libcomanche-pmstore.so"
 #define FILESTORE_PATH "libcomanche-storefile.so"
 #define NVMESTORE_PATH "libcomanche-nvmestore.so"
 #define ROCKSTORE_PATH "libcomanche-rocksdb.so"
@@ -28,6 +31,11 @@ Data * _data;
 static Component::IKVStore * g_store;
 static void initialize();
 static void cleanup();
+
+// required for nvmestore
+static Component::IBlock_device  *_block;
+static Component::IBlock_allocator *_alloc;
+static size_t _nr_blks; //number of blocks from IBlockdev
 
 struct {
   std::string test;
@@ -116,9 +124,77 @@ static void initialize()
   else if(Options.component == "filestore") {
     comp = Component::load_component(FILESTORE_PATH, Component::filestore_factory);
   }
-  // else if(Options.component == "nvmestore") {
-  //   comp = Component::load_component(NVMESTORE_PATH, Component::nvmestore_factory);
-  // }
+  else if(Options.component == "nvmestore") {
+
+    DPDK::eal_init(512);
+
+    /*
+     * init blk devices
+     */
+#ifdef USE_SPDK_NVME_DEVICE
+    
+    comp = Component::load_component("libcomanche-blknvme.so",
+                                                        Component::block_nvme_factory);
+
+    assert(comp);
+    PLOG("Block_device factory loaded OK.");
+    IBlock_device_factory * fact = (IBlock_device_factory *) comp->query_interface(IBlock_device_factory::iid());
+    
+    cpu_mask_t cpus;
+    cpus.add_core(2);
+
+    _block = fact->create("86:00.0", &cpus);
+
+    assert(_block);
+    fact->release_ref();
+    PINF("Lower block-layer component loaded OK.");
+
+#else
+    
+    comp = Component::load_component("libcomanche-blkposix.so",
+                                                        Component::block_posix_factory);
+    assert(comp);
+    PLOG("Block_device factory loaded OK.");
+
+    IBlock_device_factory * fact_blk = (IBlock_device_factory *) comp->query_interface(IBlock_device_factory::iid());
+    std::string config_string;
+    config_string = "{\"path\":\"";
+    //  config_string += "/dev/nvme0n1";1
+    config_string += "./blockfile.dat";
+    //  config_string += "\"}";
+    config_string += "\",\"size_in_blocks\":10000}";
+    PLOG("config: %s", config_string.c_str());
+
+    _nr_blks = 10000;
+
+    _block = fact_blk->create(config_string);
+    assert(_block);
+    fact_blk->release_ref();
+    PINF("Block-layer component loaded OK (itf=%p)", _block);
+#endif
+
+    /*
+     * instantiate block allocator
+     */
+    comp = load_component("libcomanche-blkalloc-aep.so",
+                                  Component::block_allocator_aep_factory);
+    assert(comp);
+    IBlock_allocator_factory * fact_blk_alloc = static_cast<IBlock_allocator_factory *>
+      (comp->query_interface(IBlock_allocator_factory::iid()));
+
+    size_t num_blocks = _nr_blks;
+    PLOG("Opening allocator to support %lu blocks", num_blocks);
+    _alloc = fact_blk_alloc->open_allocator(
+                                  num_blocks,
+                                  "nvmestore-blk-allc-1");  
+    fact_blk_alloc->release_ref();  
+
+    /*
+     * instantialize
+     */
+    comp = Component::load_component("libcomanche-nvmestore.so",
+                                                        Component::nvmestore_factory);
+  }
   else if(Options.component == "rockstore") {
     comp = Component::load_component(ROCKSTORE_PATH, Component::rocksdb_factory);
   }
@@ -127,13 +203,24 @@ static void initialize()
   assert(comp);
   IKVStore_factory * fact = (IKVStore_factory *) comp->query_interface(IKVStore_factory::iid());
 
-  g_store = fact->create("owner","name");  
+  if(Options.component == "nvmestore") {
+    g_store = fact->create("owner","name", _block, _alloc ); 
+  else{
+    g_store = fact->create("owner","name"); }
+  }
   fact->release_ref();
 }
 
 static void cleanup()
 {
   g_store->release_ref();
+
+  if(Options.component == "nvmestore") {
+    assert(_alloc);
+    assert(_block);
+    _alloc->release_ref();
+    _block->release_ref();
+  }
 }
 
 


### PR DESCRIPTION
1. nvmestore uses the same factory interface with others stores.
2. block allocator interface change: for persistent allocator, need the path and name of the pool for the persistent data
3. replaced the hardcopied PMSTORE_PATH