### PR TITLE
Nvmestore: add HOWTO and integrity test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "src/lib/flatbuffers"]
   path = src/lib/flatbuffers
   url = https://github.com/google/flatbuffers.git
+[submodule "src/lib/gdrcopy"]
+  path = src/lib/gdrcopy
+  url = https://github.com/NVIDIA/gdrcopy.git

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -4,4 +4,8 @@ set(CMAKE_CXX_STANDARD 11)
 
 add_subdirectory (block-perf)
 add_subdirectory (paging-tracker)
-#add_subdirectory(cuda-dma)
+
+find_package(CUDA)
+if(CUDA_FOUND)
+  add_subdirectory(cuda-dma)
+endif()

--- a/apps/cuda-dma/CMakeLists.txt
+++ b/apps/cuda-dma/CMakeLists.txt
@@ -1,19 +1,15 @@
 cmake_minimum_required (VERSION 3.5.1 FATAL_ERROR)
 
-
 project(cuda-dma LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
+set(CUDA_TOOLKIT_ROOT_DIR /usr/local/cuda/)
 
-#set(CMAKE_CUDA_COMPILER /usr/local/cuda-8.0/bin/nvcc)
-#set(CUDA_TOOLKIT_ROOT_DIR /usr/local/cuda-8.0/)
 set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -std=c++11 -O3 -DCONFIG_DEBUG -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_70,code=compute_70)
 set(CUDA_HOST_COMPILATION_CPP ON)
 set(CUDA_SEPARABLE_COMPILATION ON)
 set(CUDA_VERBOSE ON)
 set(CUDA_64_BIT_DEVICE_CODE ON CACHE STRING "Compile device code in 64 bit mode" FORCE)
-
-find_package(CUDA REQUIRED)
-
-
 
 message(STATUS "FoundCUDA              : ${CUDA_FOUND}")
 message(STATUS "Cuda cublas libraries  : ${CUDA_CUBLAS_LIBRARIES}")
@@ -25,8 +21,8 @@ cuda_include_directories($ENV{COMANCHE_HOME}/src/components/)
 
 cuda_add_library(cuda_app_lib src/kernel.cu)
 
-link_directories(/usr/local/cuda-9.0/lib64/)
-link_directories($ENV{COMANCHE_HOME}/deps/gdrcopy/)
+link_directories(/usr/local/cuda/lib64/)
+link_directories(${CMAKE_INSTALL_PREFIX}/lib64)
 
 file(GLOB SOURCES src/*.cpp)
 

--- a/apps/cuda-dma/README
+++ b/apps/cuda-dma/README
@@ -1,3 +1,11 @@
+gdrcpy
+-------------
+
+Gdrcopy is built during make bootstrap, but to run the application you need to install the corresponding kernel module(one time):
+```
+Comancheroot/src/deps/gdrcopy/insmod.sh
+```
+
 # Block device performance test using optionally shared polling thread.  Client threads
 # only access a single device.
 #

--- a/src/components/api/kvstore_itf.h
+++ b/src/components/api/kvstore_itf.h
@@ -358,7 +358,15 @@ public:
   DECLARE_INTERFACE_UUID(0xface829f,0x0405,0x4c19,0x9898,0xa3,0xae,0x21,0x5a,0x3e,0xe8);
 
   virtual IKVStore * create(const std::string owner,
-                            const std::string name) = 0;
+                            const std::string name){
+    throw(API_exception("Not Implemented"));
+  };
+
+  virtual IKVStore * create(const std::string owner,
+                            const std::string name,
+                            std::string pci){
+    throw(API_exception("Not Implemented"));
+  }
 
 };
 

--- a/src/components/store/nvmestore/HOWTO.md
+++ b/src/components/store/nvmestore/HOWTO.md
@@ -22,6 +22,10 @@ Enable the fake pmem
 ./setup_pmem.sh
 ```
 
+bypass clflush/msync
+```
+PMEM_IS_PMEM_FORCE=1 ./you-program
+```
 
 set pin memory limit for this user
 -------------------------------------

--- a/src/components/store/nvmestore/HOWTO.md
+++ b/src/components/store/nvmestore/HOWTO.md
@@ -8,6 +8,14 @@ Use the following parameter, huge page is for pmdk, memmap is for the pmem, inte
 hugepagesz=2M hugepages=4096 intel_iommu=on text memmap=2G!4G
 ```
 
+```
+mkdir /mnt/huge
+mount -t hugetlbfs nodev /mnt/huge
+
+```
+
+rerun tool/nvmesetup.sh
+
 Enable the fake pmem
 --------------------
 ```
@@ -28,4 +36,9 @@ Add those two lines to /et/security/limits.conf:
   fengggli hard memlock unlimited 
   fengggli soft memlock unlimited
 ```
+
+Note
+---------------
+
+you can se the clear_pmempool.sh  to clear all data from pmem
 

--- a/src/components/store/nvmestore/HOWTO.md
+++ b/src/components/store/nvmestore/HOWTO.md
@@ -45,4 +45,3 @@ Note
 ---------------
 
 you can se the clear_pmempool.sh  to clear all data from pmem
-

--- a/src/components/store/nvmestore/HOWTO.md
+++ b/src/components/store/nvmestore/HOWTO.md
@@ -1,0 +1,31 @@
+Kernel parameters
+-----------------
+
+Use the following parameter, huge page is for pmdk, memmap is for the pmem, intel_iommu must be on for vfio
+(if you are working in a machine with small memory size(e.g.no more than 8G), you should modify this correspondingly)
+
+``` 
+hugepagesz=2M hugepages=4096 intel_iommu=on text memmap=2G!4G
+```
+
+Enable the fake pmem
+--------------------
+```
+./setup_pmem.sh
+```
+
+
+set pin memory limit for this user
+-------------------------------------
+
+if you run deps/dpdk/user-tools/dpdk-setup.sh to set vfio permission and get  warning to set the ulimit:
+```
+Current user memlock limit: 0 MB
+```
+
+Add those two lines to /et/security/limits.conf:
+```  
+  fengggli hard memlock unlimited 
+  fengggli soft memlock unlimited
+```
+

--- a/src/components/store/nvmestore/setup_pmem.sh
+++ b/src/components/store/nvmestore/setup_pmem.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+sudo umount /mnt/pmem0
+sudo mkfs.ext4 /dev/pmem0
+sudo mount -o dax /dev/pmem0 /mnt/pmem0
+sudo chmod a+rwx /mnt/pmem0
+
+

--- a/src/components/store/nvmestore/src/block_helper.cpp
+++ b/src/components/store/nvmestore/src/block_helper.cpp
@@ -31,7 +31,7 @@
 
 using namespace Component;
 
-void NVME_store:: init_block_device()
+void NVME_store:: init_block_device(std::string pci)
   {
     IBlock_device *block;
 
@@ -49,7 +49,7 @@ void NVME_store:: init_block_device()
     cpu_mask_t cpus;
     cpus.add_core(2);
 
-    block = fact->create("86:00.0", &cpus);
+    block = fact->create(pci.c_str(), &cpus);
 
 
     assert(block);

--- a/src/components/store/nvmestore/src/nvme_store.cpp
+++ b/src/components/store/nvmestore/src/nvme_store.cpp
@@ -129,11 +129,12 @@ static int check_pool(const char * path)
 
 
 NVME_store::NVME_store(const std::string owner,
-                       const std::string name)
+                       const std::string name,
+                       std::string pci)
                        {
   PLOG("PMEMOBJ_MAX_ALLOC_SIZE: %lu MB", REDUCE_MB(PMEMOBJ_MAX_ALLOC_SIZE));
 
-  init_block_device();
+  init_block_device(pci);
   init_block_allocator();
 
   PINF("NVME_store: using block device %p with allocator %p", _blk_dev, _blk_alloc);

--- a/src/components/store/nvmestore/src/nvme_store.cpp
+++ b/src/components/store/nvmestore/src/nvme_store.cpp
@@ -44,9 +44,6 @@ struct store_root_t
 };
 //TOID_DECLARE_ROOT(struct store_root_t);
 
-
-
-
 struct open_session_t
 {
   TOID(struct store_root_t) root;
@@ -73,8 +70,6 @@ static open_session_t * get_session(IKVStore::pool_t pid) //open_session_t * ses
 
   return session;
 }
-
-
 
 static int check_pool(const char * path)
 {
@@ -132,10 +127,20 @@ NVME_store::NVME_store(const std::string owner,
                        const std::string name,
                        std::string pci)
                        {
+  status_t ret;
   PLOG("PMEMOBJ_MAX_ALLOC_SIZE: %lu MB", REDUCE_MB(PMEMOBJ_MAX_ALLOC_SIZE));
 
-  init_block_device(pci);
-  init_block_allocator();
+  ret = open_block_device(pci, _blk_dev);
+  if(S_OK != ret){
+    throw General_exception("failed to open block device at pci %s\n", pci.c_str());
+  }
+
+  ret = open_block_allocator(_blk_dev, _blk_alloc);
+
+  if(S_OK != ret){
+    throw General_exception("failed to open block block allocator for device at pci %s\n", pci.c_str());
+  }
+
 
   PINF("NVME_store: using block device %p with allocator %p", _blk_dev, _blk_alloc);
 }

--- a/src/components/store/nvmestore/src/nvme_store.h
+++ b/src/components/store/nvmestore/src/nvme_store.h
@@ -33,7 +33,6 @@ POBJ_LAYOUT_TOID(nvme_store, struct block_range);
 POBJ_LAYOUT_END(nvme_store);
 
 
-
 /*
  * for block allocator
  */
@@ -50,11 +49,11 @@ class NVME_store : public Component::IKVStore
 private:
   static constexpr bool option_DEBUG = true;
   static constexpr size_t BLOCK_SIZE = 4096;
-
+  
   Component::IBlock_device *_blk_dev;
   Component::IBlock_allocator *_blk_alloc;
 
-   State_map _sm; // map control
+  State_map _sm; // map control
 
 public:
   /** 
@@ -75,7 +74,6 @@ public:
 
   /** 
    * Component/interface management
-   * 
    */
   DECLARE_VERSION(0.1);
   DECLARE_COMPONENT_UUID(0x59564581,0x9e1b,0x4811,0xbdb2,0x19,0x57,0xa0,0xa6,0x84,0x57);
@@ -104,6 +102,9 @@ public:
                              uint64_t expected_obj_count = 0
                              ) override;
   
+  /*
+   * I didn't implement this, you can call create_pool directly instead
+   */
   virtual pool_t open_pool(const std::string path,
                            const std::string name,
                            unsigned int flags) override {return E_NOT_IMPL; }
@@ -195,14 +196,20 @@ private:
                       
 
   /*
-   * init the block device
+   * open the block device, reuse if it exists already
+   *
+   * @param pci in pci address of the nvme
+   * @param block out reference of block device 
+   *
+   * @return S_OK if success
    */
-  void init_block_device(std::string pci);
+  status_t open_block_device(std::string pci, Component::IBlock_device* &block);
 
   /*
-   * open an allocator for block device
+   * open an allocator for block device, reuse if it  exsits already
    */
-  void init_block_allocator();
+
+  status_t open_block_allocator(Component::IBlock_device* block, Component::IBlock_allocator* &alloc);
 };
 
 

--- a/src/components/store/nvmestore/src/nvme_store.h
+++ b/src/components/store/nvmestore/src/nvme_store.h
@@ -14,6 +14,7 @@
 
 #include <libpmemobj.h>
 
+#include <atomic>
 #include <unordered_map>
 #include <pthread.h>
 #include <common/rwlock.h>
@@ -40,7 +41,7 @@ typedef struct block_range{
   int offset;
   int size;
   void * handle; // handle to free this block
-  uint64_t last_tag; // tag for async block io
+  //uint64_t last_tag; // tag for async block io
 } block_range_t;
 
 class NVME_store : public Component::IKVStore
@@ -49,6 +50,7 @@ class NVME_store : public Component::IKVStore
 private:
   static constexpr bool option_DEBUG = true;
   static constexpr size_t BLOCK_SIZE = 4096;
+  std::unordered_map<pool_t, std::atomic<size_t>> _cnt_elem_map;
   
   Component::IBlock_device *_blk_dev;
   Component::IBlock_allocator *_blk_alloc;
@@ -175,7 +177,7 @@ public:
   virtual status_t erase(const pool_t pool,
                     uint64_t key_hash);
 
-  virtual size_t count(const pool_t pool) override{return E_NOT_IMPL;}
+  virtual size_t count(const pool_t pool) override{return _cnt_elem_map[pool];};
 
   virtual int map(const pool_t pool,
                   std::function<int(uint64_t key,

--- a/src/components/store/nvmestore/src/nvme_store.h
+++ b/src/components/store/nvmestore/src/nvme_store.h
@@ -64,7 +64,8 @@ public:
    * @param blk_alloc Block allocator
    */
   NVME_store(const std::string owner,
-             const std::string name);
+             const std::string name,
+             std::string pci);
 
   /** 
    * Destructor
@@ -196,7 +197,7 @@ private:
   /*
    * init the block device
    */
-  void init_block_device();
+  void init_block_device(std::string pci);
 
   /*
    * open an allocator for block device
@@ -229,10 +230,11 @@ public:
   }
 
   virtual Component::IKVStore * create(const std::string owner,
-                                       const std::string name)
+                                       const std::string name,
+                                       std::string pci)
                                        override
   {    
-    Component::IKVStore * obj = static_cast<Component::IKVStore*>(new NVME_store(owner, name));   
+    Component::IKVStore * obj = static_cast<Component::IKVStore*>(new NVME_store(owner, name,pci));   
     obj->add_ref();
     return obj;
   }

--- a/src/components/store/nvmestore/unit_test/CMakeLists.txt
+++ b/src/components/store/nvmestore/unit_test/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(test-nvmestore test-nvmestore.cpp)
+add_executable(test-integrity test-integrity.cpp)
 
 include_directories(${CONF_COMANCHE_HOME}/testing)
 find_library(GTEST_LIB NAMES GTEST PATHS /usr/local/lib,/usr/lib)
 add_definitions(${GCC_COVERAGE_COMPILE_FLAGS} -DCONFIG_DEBUG)
 
-
-
 target_link_libraries(test-nvmestore ${LIB_PMEM} ${LIB_PMEMOBJ} ${ASAN_LIB}  common comanche-core numa gtest pthread dl comanche-allocblock profiler)
+target_link_libraries(test-integrity ${LIB_PMEM} ${LIB_PMEMOBJ} ${ASAN_LIB}  common comanche-core numa gtest pthread dl comanche-allocblock profiler)
 
 

--- a/src/components/store/nvmestore/unit_test/test-integrity.cpp
+++ b/src/components/store/nvmestore/unit_test/test-integrity.cpp
@@ -1,0 +1,196 @@
+/*
+ * (C) Copyright IBM Corporation 2018. All rights reserved.
+ *
+ */
+
+/* 
+ * Authors: 
+ * 
+ * Feng Li (fengggli@yahoo.com)
+ *
+ */
+
+
+/* note: we do not include component source, only the API definition */
+#include <gtest/gtest.h>
+#include <common/utils.h>
+#include <common/str_utils.h>
+#include <core/physical_memory.h>
+#include <api/components.h>
+#include <api/kvstore_itf.h>
+#include <api/block_itf.h>
+#include <api/block_allocator_itf.h>
+#include "data.h"
+
+#include <stdlib.h>
+
+#include <gperftools/profiler.h>
+
+
+
+using namespace Component;
+
+static Component::IKVStore::pool_t pool;
+
+struct
+{
+  std::string pci;
+} opt;
+
+namespace {
+
+
+// The fixture for testing class Foo.
+class KVStore_test : public ::testing::Test {
+
+ protected:
+
+  // If the constructor and destructor are not enough for setting up
+  // and cleaning up each test, you can define the following methods:
+  
+  virtual void SetUp() {
+    // Code here will be called immediately after the constructor (right
+    // before each test).
+  }
+
+  virtual void TearDown() {
+    // Code here will be called immediately after each test (right
+    // before the destructor).
+  }
+  
+  // Objects declared here can be used by all tests in the test case
+  static Component::IBlock_device * _block;
+  static Component::IBlock_allocator * _alloc;
+  static Component::IKVStore * _kvstore;
+  static Component::IKVStore * _kvstore2;
+
+  static std::string POOL_NAME;
+};
+
+
+Component::IKVStore * KVStore_test::_kvstore;
+//Component::IKVStore * KVStore_test::_kvstore2;
+
+std::string KVStore_test::POOL_NAME = "test-nvme";
+constexpr static int nr_elem = 500; // number of the test elem in the pool
+
+#define PMEM_PATH "/mnt/pmem0/pool/0/"
+//#define PMEM_PATH "/dev/pmem0"
+
+
+TEST_F(KVStore_test, Instantiate)
+{
+  /* create object instance through factory */
+  Component::IBase * comp = Component::load_component("libcomanche-nvmestore.so",
+                                                      Component::nvmestore_factory);
+
+  ASSERT_TRUE(comp);
+  IKVStore_factory * fact = (IKVStore_factory *) comp->query_interface(IKVStore_factory::iid());
+
+  // this nvme-store use a block device and a block allocator
+  _kvstore = fact->create("owner","name", opt.pci.c_str());
+  
+  fact->release_ref();
+}
+
+TEST_F(KVStore_test, OpenPool)
+{
+  PLOG(" test-nvmestore: try to openpool");
+  ASSERT_TRUE(_kvstore);
+  std::string pool_name = POOL_NAME + ".pool";
+  // pass blk and alloc here
+  pool = _kvstore->create_pool(PMEM_PATH, pool_name.c_str(), GB(8));
+  ASSERT_TRUE(pool > 0);
+}
+
+TEST_F(KVStore_test, BasicPut)
+{
+  ASSERT_TRUE(pool);
+  for(int i=0 ;i< nr_elem; i++){
+    std::string key = "MyKey"+std::to_string(i);
+    std::string value = "Hello world!"+std::to_string(i);
+    //  value.resize(value.length()+1); /* append /0 */
+    value.resize(MB(8));
+      
+    EXPECT_TRUE(S_OK == _kvstore->put(pool, key, value.c_str(), value.length()));
+  }
+}
+
+#if 0
+TEST_F(KVStore_test, GetDirect)
+{
+
+  /*Register Mem is only from gdr memory*/
+  //ASSERT_TRUE(S_OK == _kvstore->register_direct_memory(user_buf, MB(8)));
+  io_buffer_t handle;
+  Core::Physical_memory  mem_alloc; // aligned and pinned mem allocator, TODO: should be provided through IZerocpy Memory interface of NVMestore
+  std::string key = "MyKey0";
+  void * value = nullptr;
+  size_t value_len = 0;
+
+  handle = mem_alloc.allocate_io_buffer(MB(8), 4096, Component::NUMA_NODE_ANY);
+  ASSERT_TRUE(handle);
+  value = mem_alloc.virt_addr(handle);
+
+  _kvstore->get_direct(pool, key, value, value_len, 0);
+
+  EXPECT_FALSE(strcmp("Hello world!0", (char*)value));
+  PINF("Value=(%.50s) %lu", ((char*)value), value_len);
+
+  mem_alloc.free_io_buffer(handle);
+}
+#endif
+
+TEST_F(KVStore_test, BasicGet)
+{
+
+  for(int i=0 ;i< nr_elem; i++){
+    std::string key = "MyKey"+ std::to_string(i);
+
+    void * value = nullptr;
+    size_t value_len = 0;
+    _kvstore->get(pool, key, value, value_len);
+
+    std::string expected_value = "Hello world!" + std::to_string(i);
+    EXPECT_FALSE(strcmp(expected_value.c_str(), (char*)value));
+    PINF("Value=(%.50s) %lu", ((char*)value), value_len);
+  }
+}
+
+TEST_F(KVStore_test, BasicErase)
+{
+
+  for(int i=0 ;i< nr_elem; i++){
+    _kvstore->erase(pool, "MyKey"+std::to_string(i));
+  }
+
+}
+
+
+TEST_F(KVStore_test, ClosePool)
+{
+  _kvstore->close_pool(pool);
+}
+
+TEST_F(KVStore_test, ReleaseStore)
+{
+  _kvstore->release_ref();
+}
+
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if(argc!=2) {
+    PINF("test-nvmestore <pci-address>");
+    return 0;
+  }
+
+  opt.pci = argv[1];
+
+  
+  ::testing::InitGoogleTest(&argc, argv);
+  auto r = RUN_ALL_TESTS();
+
+  return r;
+}

--- a/src/components/store/nvmestore/unit_test/test-nvmestore.cpp
+++ b/src/components/store/nvmestore/unit_test/test-nvmestore.cpp
@@ -32,7 +32,13 @@ using namespace Component;
 
 static Component::IKVStore::pool_t pool;
 
+struct
+{
+  std::string pci;
+} opt;
+
 namespace {
+
 
 // The fixture for testing class Foo.
 class KVStore_test : public ::testing::Test {
@@ -79,7 +85,7 @@ TEST_F(KVStore_test, Instantiate)
   IKVStore_factory * fact = (IKVStore_factory *) comp->query_interface(IKVStore_factory::iid());
 
   // this nvme-store use a block device and a block allocator
-  _kvstore = fact->create("owner","name");
+  _kvstore = fact->create("owner","name", opt.pci.c_str());
   
   fact->release_ref();
 }
@@ -267,6 +273,13 @@ TEST_F(KVStore_test, ReleaseStore)
 } // namespace
 
 int main(int argc, char **argv) {
+  if(argc!=2) {
+    PINF("test-nvmestore <pci-address>");
+    return 0;
+  }
+
+  opt.pci = argv[1];
+
   
   ::testing::InitGoogleTest(&argc, argv);
   auto r = RUN_ALL_TESTS();

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -62,5 +62,16 @@ ExternalProject_Add(libfabric
   INSTALL_COMMAND make install
   )
 
+find_package(CUDA)
+if(CUDA_FOUND)
+  ExternalProject_Add(gdrcopy  
+    BUILD_IN_SOURCE 1
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gdrcopy
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND make PREFIX=${CMAKE_INSTALL_PREFIX}  CUDA=${CUDA_TOOLKIT_ROOT_DIR} all install
+    INSTALL_COMMAND ""
+    )
+endif()
+
 
 

--- a/src/lib/common/include/common/exceptions.h
+++ b/src/lib/common/include/common/exceptions.h
@@ -42,7 +42,10 @@
 #include <cstdarg>
 #include <string>
 
+#ifndef STRINGIFY
 #define STRINGIFY(x) #x
+#endif
+
 #define TOSTRING(x) STRINGIFY(x)
 #define ADD_LOC(X) X __FILE__ ":" TOSTRING(__LINE__)
 

--- a/src/lib/core/src/physical_memory.cpp
+++ b/src/lib/core/src/physical_memory.cpp
@@ -173,7 +173,7 @@ Component::io_buffer_t Physical_memory::register_memory_for_io(void* vaddr, addr
   int rc = spdk_mem_register(vaddr, len);
 
   if(spdk_vtophys(vaddr) !=  paddr)
-    throw General_exception("SPDK address registration check failed (rc=%d)", rc);
+    throw General_exception("SPDK address registration check failed (rc=%d), spdk_vtophys returns physcial address 0x%lx != 0x%lx", rc,spdk_vtophys(vaddr), paddr);
   
   return reinterpret_cast<Component::io_buffer_t>(vaddr);
 }

--- a/testing/kvstore/data.h
+++ b/testing/kvstore/data.h
@@ -4,7 +4,7 @@
 class Data
 {
 public:
-  static constexpr size_t NUM_ELEMENTS = 1000000; // 10M
+  static constexpr size_t NUM_ELEMENTS = 1000000; // 1M
   static constexpr size_t KEY_LEN = 8;
   static constexpr size_t VAL_LEN = 64;
 

--- a/testing/kvstore/kvstore_perf.cpp
+++ b/testing/kvstore/kvstore_perf.cpp
@@ -127,7 +127,12 @@ static void initialize()
   assert(comp);
   IKVStore_factory * fact = (IKVStore_factory *) comp->query_interface(IKVStore_factory::iid());
 
-  g_store = fact->create("owner","name");
+  if(Options.component == "nvmestore"){
+    g_store = fact->create("owner","name", "81:00.0");
+  }
+  else{
+    g_store = fact->create("owner","name");
+  }
   fact->release_ref();
 }
 


### PR DESCRIPTION
* nvmestore, signature changed for create: create(owner, name, pci_address)
* add nvmestore integrity test.
* improved the block_helper to support multiples store on the same nvme.
* gdrcopy now is now a submodule, not built if no cuda installed(e.g. autobuild in travis).
* spdk path needs to installed to make cuda-dma work