### PR TITLE
Nvmestore kvperf local

### DIFF
--- a/src/components/store/filestore/src/file_store.cpp
+++ b/src/components/store/filestore/src/file_store.cpp
@@ -174,7 +174,7 @@ status_t Pool_handle::get(const std::string& key,
   
   std::string full_path = path.string() + "/" + key;
   if(!fs::exists(full_path)) {
-    PERR("key not found: (%s)", full_path.c_str());
+    PWRN("key not found: (%s)", full_path.c_str());
     return IKVStore::E_KEY_NOT_FOUND;
   }
 

--- a/src/components/store/nvmestore/CHANGELOG.md
+++ b/src/components/store/nvmestore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 This is the changelog for nvmestore
+[2019-07-16]:
+Updates:
+* tweaked nvmestore for kvperf-local, see issue #12 for performance evaluation.
+* Nees more work on kvperf-dawn. Since shard cannot wait for expensive lock/unlock operation in nvmestore, I could either (I will focus on 2): 
+  1. improve dawn protocal to support asynchronous lock/unlock.
+  2. switch to file system integration instead, benchmarking with fio etc.
 [2019-07-10]:
 * Added:
   1. use meta_store->get instead of meta_store->map_keys to check whether key exists, solve performance issue in #11.

--- a/src/components/store/nvmestore/run_local_exp.sh
+++ b/src/components/store/nvmestore/run_local_exp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# First created: 
+# Last modified: 2018 Jan 26
+
+# Author: Feng Li
+# email: fengggli@yahoo.com
+
+PCI_ADDR="11:00.0"
+NR_ELEMS=100000  # nr_elem for 4k
+for VAL_LEN in 4096 65536 1048576 16777216 268435456
+do
+  for EXP_NAME in "put" "get" "get_direct"
+  do
+
+  echo "########### Runing ${EXP_NAME} with VAL_LEN=${VAL_LEN}, NR_ELEMS=${NR_ELEMS}, using pci_addr=${PCI_ADDR}"
+
+  ./testing/kvstore/kvstore-perf --component nvmestore --pci_addr ${PCI_ADDR} --test=${EXP_NAME} --value_length=${VAL_LEN} --elements=${NR_ELEMS}
+
+  done
+  NR_ELEMS=$((NR_ELEMS/10))
+done
+

--- a/src/components/store/nvmestore/run_local_exp.sh
+++ b/src/components/store/nvmestore/run_local_exp.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-# First created: 
-# Last modified: 2018 Jan 26
-
-# Author: Feng Li
-# email: fengggli@yahoo.com
-
 PCI_ADDR="11:00.0"
 NR_ELEMS=100000  # nr_elem for 4k
 for VAL_LEN in 4096 65536 1048576 16777216 268435456

--- a/src/components/store/nvmestore/src/meta_store.h
+++ b/src/components/store/nvmestore/src/meta_store.h
@@ -37,7 +37,7 @@ class MetaStore {
     if (_persist_type ==
         PERSIST_FILE) { /* components that support debug level */
       std::map<std::string, std::string> params;
-      params["pm_path"] = pm_path + "meta/";
+      params["pm_path"] = pm_path + "/meta/";
       _store            = fact->create(debug_level, params);
     }
     else if (_persist_type == PERSIST_HSTORE) {

--- a/src/components/store/nvmestore/src/nvme_store.cpp
+++ b/src/components/store/nvmestore/src/nvme_store.cpp
@@ -325,7 +325,7 @@ status_t NVME_store::get(const pool_t       pool,
   open_session_t* session = reinterpret_cast<open_session_t*>(pool);
 
   if (g_sessions.find(session) == g_sessions.end())
-    throw API_exception("NVME_store::put invalid pool identifier");
+    throw API_exception("NVME_store::get invalid pool identifier");
 
   return session->get(key, out_value, out_value_len);
 }
@@ -339,7 +339,7 @@ status_t NVME_store::get_direct(const pool_t       pool,
   open_session_t* session = reinterpret_cast<open_session_t*>(pool);
 
   if (g_sessions.find(session) == g_sessions.end())
-    throw API_exception("NVME_store::put invalid pool identifier");
+    throw API_exception("NVME_store::get_direct invalid pool identifier");
 
   return session->get_direct(key, out_value, out_value_len,
                              reinterpret_cast<buffer_t*>(handle));

--- a/src/components/store/nvmestore/src/nvme_store.h
+++ b/src/components/store/nvmestore/src/nvme_store.h
@@ -143,6 +143,13 @@ class NVME_store : public Component::IKVStore {
                        const void*        value,
                        const size_t       value_len,
                        unsigned int       flags = FLAGS_NONE) override;
+  virtual status_t put_direct(const pool_t       pool,
+                       const std::string& key,
+                       const void*        value,
+                       const size_t       value_len,
+                       memory_handle_t memory_handle,
+                       unsigned int       flags = FLAGS_NONE) override;
+
 
   virtual status_t get(const pool_t       pool,
                        const std::string& key,

--- a/testing/kvstore/experiment.cpp
+++ b/testing/kvstore/experiment.cpp
@@ -4,6 +4,7 @@
 #include "get_vector_from_string.h"
 #include "program_options.h"
 
+#include <common/str_utils.h>
 #include "rapidjson/filereadstream.h"
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/stringbuffer.h"
@@ -1049,6 +1050,9 @@ std::string Experiment::create_report(const std::string component_)
   document.Accept(writer);
 
   std::string output_file_name = specific_results_path + "/results_" + timestring + ".json";
+  if(boost::filesystem::exists(output_file_name)){ // Don't overwrite
+    output_file_name = specific_results_path + "/results_" + timestring + "-copy(" + Common::random_string(3) +").json";
+  }
   std::ofstream outf(output_file_name);
 
   if ( outf )


### PR DESCRIPTION
#### Added
1. tweaked nvmestore for kvperf-local(use 2M aligned anonymous mmaped memory for rdma and spdk registration)
2. script to run nvmestore kvperf-local experiments

switching to filesystem integration.